### PR TITLE
Pruebas unitarias en ReporteController

### DIFF
--- a/Trackme/src/main/java/com/trackme/controller/ReporteController.java
+++ b/Trackme/src/main/java/com/trackme/controller/ReporteController.java
@@ -23,7 +23,7 @@ public class ReporteController {
     private static final int MIN_AÑO_DESAPARICION = 2024;
 
     @Value("${feature.create-reports.enabled}")
-    private boolean createReportsEnabled;
+    public boolean createReportsEnabled;
 
     @Autowired
     private PersonaDesaparecidaService personaDesaparecidaService;

--- a/Trackme/src/test/java/com/trackme/controller/ReporteControllerTest.java
+++ b/Trackme/src/test/java/com/trackme/controller/ReporteControllerTest.java
@@ -132,4 +132,28 @@ class ReporteControllerTest {
         );
         verify(personaDesaparecidaService, times(1)).obtenerTodosLosReportes();
     }
+
+    @Test
+    void crearReporte_ConNombreInvalido_DeberiaRetornarBadRequest() {
+        reporteController.createReportsEnabled = true;
+        PersonaDesaparecida reporteInvalido = crearReporteEjemplo(null, "test@example.com", "1");
+        ResponseEntity<?> response = reporteController.crearReporte(reporteInvalido);
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode(), "Debería retornar BAD_REQUEST");
+    }
+
+    @Test
+    void crearReporte_FuncionalidadDeshabilitada_DeberiaRetornarForbidden() throws Exception {
+        reporteController = new ReporteController() {{
+            personaDesaparecidaService = ReporteControllerTest.this.personaDesaparecidaService;
+            createReportsEnabled = false;
+        }};
+        PersonaDesaparecida reporteValido = crearReporteEjemplo(4L, "usuario@example.com", "Carlos López");
+        ResponseEntity<?> response = reporteController.crearReporte(reporteValido);
+        assertAll(
+                () -> assertEquals(HttpStatus.FORBIDDEN, response.getStatusCode(), "Debería retornar FORBIDDEN"),
+                () -> assertEquals("La funcionalidad de creación de reportes está deshabilitada.", response.getBody())
+        );
+        verify(personaDesaparecidaService, never()).crearReporte(any());
+    }
+
 }


### PR DESCRIPTION
Cambios realizados:
- Se agregó la prueba crearReporte_FuncionalidadDeshabilitada_DeberiaRetornarForbidden, que valida el retorno de 403 Forbidden cuando la creación de reportes está deshabilitada.
- Se añadió la prueba crearReporte_ConNombreInvalido_DeberiaRetornarBadRequest, que verifica que se retorne 400 Bad Request ante un nombre inválido.

Justificación:
Estas pruebas aseguran que el controlador maneje correctamente los escenarios donde:
- La funcionalidad está deshabilitada.
- El input del usuario es inválido.
- Se mejora la cobertura y se previenen errores lógicos en producción.